### PR TITLE
Align docs on single virtual environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ ocr_pipeline/
 
 ## Installation & Quick‑start
 
-### 1. Set up virtual environment
+### 1. Set up the `venv` virtual environment
 
 **Requirements:** Python 3.8+ (tested with Python 3.13)
 

--- a/agents.md
+++ b/agents.md
@@ -12,7 +12,7 @@ These files are essential for testing the OCR pipeline across different formats 
 
 ### Test Environment
 - Python 3.13.2
-- Virtual environment: `venv_new/`
+- Virtual environment: `venv/`
 - Dependencies installed from `requirements.txt`
 
 ### OCR Pipeline Structure
@@ -35,7 +35,7 @@ The pipeline supports multiple OCR backends:
 
 1. **Environment Setup**:
    ```bash
-   source venv_new/bin/activate
+   source venv/bin/activate
    ```
 
 2. **Test with Images**:


### PR DESCRIPTION
## Summary
- update README heading to explicitly mention the `venv` virtual environment
- change agents.md to refer to `venv` and update activation snippet

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685952abd738832aa94a5ed698d3152f