### PR TITLE
Add advanced deskew and binarisation preprocessing

### DIFF
--- a/tests/test_multilingual.py
+++ b/tests/test_multilingual.py
@@ -9,7 +9,7 @@ import config
 
 @patch('pipeline.np')
 @patch('pipeline._auto_rotate', return_value=Mock())
-@patch('pipeline.preprocess_image', return_value=Mock())
+@patch('pipeline.preprocess', return_value=(Mock(), {}))
 @patch('pipeline.pytesseract')
 @patch('pipeline.easyocr')
 @patch('pipeline.PaddleOCR')


### PR DESCRIPTION
## Summary
- implement new `preprocess` function with deskew, CLAHE and Sauvola
- update Tesseract OCR to use the new preprocessing pipeline
- adjust legacy `preprocess_image` wrapper
- patch tests for new function and add preprocessing unit test
- fix electricity extraction when digits have spaces or commas

## Testing
- `pip install --user pdf2image pytesseract numpy opencv-python-headless scikit-image pdfminer.six`
- `sudo apt-get update && sudo apt-get install -y tesseract-ocr poppler-utils`
- `pytest -q`
- `python pipeline.py ActualBill.pdf`

------
https://chatgpt.com/codex/tasks/task_e_6859c30e7670832aaf5b1d38f9527090